### PR TITLE
Fix ipc loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-electron-store",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Redux store which synchronizes between instances in multiple process",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Because `store.dispatch` is overridden, we would skip the `synchronous` check and fall into an `ipc` loop.  In 0.2.6, this actually called [`super.dispatch`](https://github.com/samiskin/redux-electron-store/pull/2/files#diff-02a56a63200d71dd870eb891b58a9457L90), which I've extracted as `doDispatch` here.