### PR TITLE
Restores default dispatch return value

### DIFF
--- a/src/electronBrowserEnhancer.js
+++ b/src/electronBrowserEnhancer.js
@@ -109,6 +109,8 @@ export default function electronBrowserEnhancer({
             webContents.send(`${globalName}-browser-dispatch`, transfer);
           }
         }
+
+        return action;
       };
 
       return store;

--- a/src/electronRendererEnhancer.js
+++ b/src/electronRendererEnhancer.js
@@ -92,6 +92,8 @@ export default function electronRendererEnhancer({
         }
 
         ipcRenderer.send(`${globalName}-renderer-dispatch`, JSON.stringify({ action, clientId }));
+
+        return action;
       };
 
       return store;


### PR DESCRIPTION
Fixes #24 

Tested both Main and Renderer side using a `console.log()` on the `dispatch` call.

```JavaScript
console.log(store.dispatch({ type: 'DO_NOTHING' }));
```

Each call successfully resulted in the following outputs:

**Renderer:**
```JavaScript
Object {type: "DO_NOTHING", source: "window 1"}
```

**Main (electronBrowserEnhancer):**
```bash
...
 { type: 'DO_NOTHING', source: 'main_process' }
...
```