### PR TITLE
Avoid putting remote objects in the store

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,1 @@
+export const globalName = '__REDUX_ELECTRON_STORE__';

--- a/src/contains-remote-object.js
+++ b/src/contains-remote-object.js
@@ -1,0 +1,22 @@
+import isObject from 'lodash/isObject';
+import isFunction from 'lodash/isFunction';
+
+/**
+ * Determines if an object is, or contains, an Electron remote object.
+ * Under the surface, getting or setting properties on remote objects triggers
+ * synchronous IPC messages. So we want to avoid storing them at all costs.
+ *
+ * Refer to https://github.com/electron/electron/blob/master/docs/api/remote.md#remote-objects.
+ *
+ * @param  {Object} obj An object to test
+ * @return {Boolean}    True if it is a remote object, false otherwise
+ */
+export function containsRemoteObject(obj) {
+  if (!process || !process.atomBinding) return false;
+  if (!isObject(obj) && !isFunction(obj)) return false;
+
+  const v8util = process.atomBinding('v8_util');
+  if (v8util.getHiddenValue(obj, 'atomId')) return true;
+
+  return Object.keys(obj).find((x) => containsRemoteObject(obj[x]));
+}


### PR DESCRIPTION
When `getState` is called from the renderer, what it's actually doing is creating an object in the main process. When we iterate that object for `cloneDeep`, each property look-up translates to an `ipc.sendSync` (this is similar to the situation in https://github.com/electron/electron/issues/3856). We can avoid this whole rigmarole if we just use a primitive type, so instead, we'll stringify it.

This does add the requirement that everything you put in the store must be serializable (reasonable IMO). If you stored something like an `Error` or a `RegExp` this would break down.