### PR TITLE
Make post-dispatch happen after dispatch

### DIFF
--- a/src/electronBrowserEnhancer.js
+++ b/src/electronBrowserEnhancer.js
@@ -54,7 +54,6 @@ export default function electronBrowserEnhancer({
         try {
           preDispatchCallback(action);
           storeDotDispatch(action);
-          postDispatchCallback(action);
         } finally {
           reduxState.isDispatching = false;
         }
@@ -132,6 +131,7 @@ export default function electronBrowserEnhancer({
 
         senderClientId = null;
         subscribeFuncs.callListeners();
+        postDispatchCallback(action);
 
         return action;
       };

--- a/src/electronRendererEnhancer.js
+++ b/src/electronRendererEnhancer.js
@@ -87,7 +87,6 @@ export default function electronRendererEnhancer({
         try {
           preDispatchCallback(action);
           storeDotDispatch(action);
-          postDispatchCallback(action);
         } finally {
           reduxState.isDispatching = false;
         }
@@ -100,6 +99,7 @@ export default function electronRendererEnhancer({
           mainProcessUpdateFlag = true;
           doDispatch(actionParsed);
           subscribeFuncs.callListeners();
+          postDispatchCallback();
         }
       });
 
@@ -117,6 +117,7 @@ export default function electronRendererEnhancer({
         }
 
         subscribeFuncs.callListeners();
+        postDispatchCallback(action);
         return action;
       };
 


### PR DESCRIPTION
When the order of operations for `subscribe` listeners [changed](https://github.com/samiskin/redux-electron-store/commit/95decf069582979bdf812b257e80464f60ec42ca), `postDispatchCallback` wasn't changed with it. This meant that components that depended on it would update themselves with stale data.