### PR TITLE
Fix bug with refreshing internal webviews

### DIFF
--- a/src/main-enhancer.js
+++ b/src/main-enhancer.js
@@ -52,7 +52,7 @@ module.exports = overrides => storeCreator => (reducer, initialState) => {
       webContents: sender,
       filter,
       clientId,
-      windowId: sender.getOwnerBrowserWindow().id,
+      //windowId: sender.getOwnerBrowserWindow().id,
       active: true
     };
 

--- a/src/main-enhancer.js
+++ b/src/main-enhancer.js
@@ -30,6 +30,7 @@ module.exports = overrides => storeCreator => (reducer, initialState) => {
   // Need to keep track of windows, as when a window refreshes it creates a new
   // webContents, and the old one must be unregistered
   let windowMap = {} // windowId -> webContentsId
+  let viewMap = {}
 
   // Cannot delete data, as events could still be sent after close
   // events when a BrowserWindow is created using remote

--- a/src/main-enhancer.js
+++ b/src/main-enhancer.js
@@ -45,11 +45,20 @@ module.exports = overrides => storeCreator => (reducer, initialState) => {
       if (!isGuest) {
         // For windowMap (not webviews)
         let browserWindow = sender.getOwnerBrowserWindow()
-        if (windowMap[browserWindow.id] !== undefined) {
-          // Occurs on window reload
-          unregisterRenderer(windowMap[browserWindow.id])
+        let browserView = BrowserView.fromWebContents(sender)
+
+        if (browserView) {
+          if (viewMap[browserView.id]) {
+            unregisterRenderer(windowMap[browserWindow.id])
+          }
+          viewMap[browserView.id] = webContentsId
+        } else {
+          if (windowMap[browserWindow.id]) {
+            // Occurs on window reload            
+            unregisterRenderer(windowMap[browserWindow.id])
+          }
+          windowMap[browserWindow.id] = webContentsId
         }
-        windowMap[browserWindow.id] = webContentsId
 
         // Webcontents aren't automatically destroyed on window close
         browserWindow.on('closed', () => unregisterRenderer(webContentsId))

--- a/src/main-enhancer.js
+++ b/src/main-enhancer.js
@@ -38,7 +38,7 @@ module.exports = overrides => storeCreator => (reducer, initialState) => {
   };
 
   ipcMain.on(`${globalName}-register-renderer`, ({ sender }, { filter, clientId }) => {
-    let webContentsId = sender.getId();
+    let webContentsId = sender.id;
 
     // if webviews are reloaded, the contents id changes
     // so duplicates need to be removed

--- a/src/main-enhancer.js
+++ b/src/main-enhancer.js
@@ -1,5 +1,5 @@
 // {params, flags, storeCreator, reducer, initialState, forwarder}
-const { ipcMain } = require('electron')
+const { ipcMain, BrowserView } = require('electron')
 const { globalName } = require('./constants')
 const fillShape = require('./utils/fill-shape')
 const setupStore = require('./setup-electron-store')

--- a/src/renderer-enhancer.js
+++ b/src/renderer-enhancer.js
@@ -37,8 +37,9 @@ module.exports = overrides => storeCreator => (reducer, providedInitialState) =>
   const rendererId = process.guestInstanceId || remote.getCurrentWindow().id;
   const clientId = process.guestInstanceId ? `webview ${rendererId}` : `window ${rendererId}`;
 
+  const isGuest = !!process.guestInstanceId;
   // Allows the main process to forward updates to this renderer automatically
-  ipcRenderer.send(`${globalName}-register-renderer`, { filter: params.filter, clientId });
+  ipcRenderer.send(`${globalName}-register-renderer`, { filter: params.filter, clientId, isGuest });
 
   // Get current from the electronEnhanced store in the browser through the global it creates
   let getInitialState = remote.getGlobal(globalName);

--- a/src/utils/object-difference.js
+++ b/src/utils/object-difference.js
@@ -8,9 +8,9 @@
     {updated: {b: 2}, deleted: {a: true}}
 */
 
-const isObject = require('lodash/isObject');
-const isEmpty = require('lodash/isEmpty');
-const keys = require('lodash/keys');
+const isObject = require("lodash/isObject");
+const isEmpty = require("lodash/isEmpty");
+const keys = require("lodash/keys");
 
 const isShallow = val => Array.isArray(val) || !isObject(val);
 
@@ -19,6 +19,8 @@ module.exports = function objectDifference(old, curr) {
   const deleted = {};
 
   keys(curr).forEach(key => {
+    if (old[key] === curr[key]) return;
+
     if (isShallow(curr[key]) || isShallow(old[key])) {
       updated[key] = curr[key];
     } else {
@@ -28,8 +30,7 @@ module.exports = function objectDifference(old, curr) {
     }
   });
 
-  keys(old)
-    .forEach(key => curr[key] === undefined && (deleted[key] = true));
+  keys(old).forEach(key => curr[key] === undefined && (deleted[key] = true));
 
   return { updated, deleted };
 };

--- a/src/utils/object-difference.js
+++ b/src/utils/object-difference.js
@@ -8,9 +8,9 @@
     {updated: {b: 2}, deleted: {a: true}}
 */
 
-const isObject = require("lodash/isObject");
-const isEmpty = require("lodash/isEmpty");
-const keys = require("lodash/keys");
+const isObject = require('lodash/isObject');
+const isEmpty = require('lodash/isEmpty');
+const keys = require('lodash/keys');
 
 const isShallow = val => Array.isArray(val) || !isObject(val);
 


### PR DESCRIPTION
In my application I have the ability to `reload()` an internal webview. When doing this the webcontents id changes (but the webcontents doesnt), so it ends up duplicating the client in the main process. This has the unwanted side effect of duplicating actions through ipc.

My fix is simple, it just checks for duplicated and removes the clients with the incorrect (old) id. The important code is:
```
// if webviews are reloaded, the contents id changes
// so duplicates need to be removed
Object.keys(clients).forEach(k => {
  if (clients[k].webContents === sender) {
    delete clients[k];
  }
});
```

The other changes were created by my prettier setup and shouldn't change anything.

I'm not fully aware if this will create other problems, so welcome to feedback.